### PR TITLE
docs: report obuild bundling issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,22 @@
 # obuild-bug-report
 
-write bug report here
+## Bug Report: `obuild` skips dependency bundling
+
+### Steps to Reproduce
+1. Install dependencies with `pnpm install`.
+2. Run the bundler: `pnpm build-obuild`.
+3. Inspect the output file `dist-obuild/main.mjs` – it still contains `import { v4 } from "uuid";` instead of the bundled code.
+4. Compare with `pnpm build-rolldown`, where `dist-rolldown/main.js` includes the `uuid` implementation inlined in the bundle.
+
+### Expected Behavior
+`obuild` should bundle runtime dependencies like `uuid` into the output so the generated file can be published without requiring external packages.
+
+### Actual Behavior
+`dist-obuild/main.mjs` references `uuid` as an external import and does not include its source.
+
+### Additional Information
+- `obuild` version: 0.2.1
+- `rolldown` version: 1.0.0-beta.33
+- Node.js version: v20.19.4
+
+It is unclear how to configure `obuild` to bundle dependencies. Guidance or a fix would help when publishing bundled code.


### PR DESCRIPTION
## Summary
- document that obuild leaves dependencies like `uuid` unbundled
- note that rolldown bundles the dependency with similar config

## Testing
- `npm test` (fails: Missing script "test")


------
https://chatgpt.com/codex/tasks/task_e_68a5641eff6c83238253abe68d0167d1

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a comprehensive Bug Report section to the README, replacing placeholder text.
  * Documents issue where obuild skips bundling runtime dependencies for clarity and troubleshooting.
  * Includes clear Steps to Reproduce, Expected vs Actual Behavior, and Additional Information with environment details.
  * Improves guidance for filing actionable bug reports and diagnosing environment-related issues.
  * No code or public API changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->